### PR TITLE
Add CSV flush after writerow call

### DIFF
--- a/sds011/examples/sds011_console_test.py
+++ b/sds011/examples/sds011_console_test.py
@@ -15,6 +15,7 @@ try:
             meas = sds.read_measurement()
             vals = [str(meas.get(k)) for k in logcols]
             log.writerow(vals)
+            csvfile.flush()
             print(vals)
             
             


### PR DESCRIPTION
Hi @menschel,

Thanks for creating this useful library. The CSV file remains 0kB on Windows, because the file remains open without graceful closing when stopping the Python script. I've added a flush to the CSV file which solves the problem.

Can you review this change and merge this into master?